### PR TITLE
fix typo together

### DIFF
--- a/src/templates/index.js
+++ b/src/templates/index.js
@@ -50,8 +50,7 @@ const IndexPage = ({ data }) => {
                     <Contact
                         headerText1="Let's"
                         headerText2="work"
-                        headerText3="toget"
-                        headerText4="her"
+                        headerText3="together"
                         nameInputPlaceholder="name"
                         messageInputPlaceholder="message"
                         buttonLabel="Send"


### PR DESCRIPTION
Change text from split to 3 and 4 line to be full on 3 line for text `together`

Before change:

![image](https://github.com/flotiq/flotiq-gatsby-portfolio-2/assets/110835434/ab4eed7f-3c31-46a1-a6f5-79ed7e601688)


After change:

![image](https://github.com/flotiq/flotiq-gatsby-portfolio-2/assets/110835434/a94a7d9f-b072-4812-94e7-e75ddf65ef1e)
